### PR TITLE
Update library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Vlpp
 maintainer=Marcus Rugger <marcusrugger@yahoo.com>
 sentence=Provides function templates to better support functional programming
 paragraph=
-category=Library
+category=Other
 url=http://github.com/marcusrugger/functional-vlpp
 architectures=avr


### PR DESCRIPTION
Vlpp for Arduino include a wrong category description in
library.property. This causes warnings when it is built.
